### PR TITLE
feat: :art: added api controller versioning

### DIFF
--- a/examples/basic-server/src/main.rs
+++ b/examples/basic-server/src/main.rs
@@ -8,7 +8,7 @@ pub struct MyConfig {
     custom_key: String,
 }
 
-#[controller("/")]
+#[controller("/", version = "v1")]
 struct AppController {}
 
 #[routes]

--- a/sword-macros/src/controller/parsing/attributes.rs
+++ b/sword-macros/src/controller/parsing/attributes.rs
@@ -1,0 +1,43 @@
+use regex::Regex;
+use std::sync::LazyLock;
+use syn::{
+    Ident, LitStr, Token,
+    parse::{Parse, ParseStream},
+};
+
+static VERSION_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"v\d+").expect("Failed to compile version regex"));
+
+// #[controller("/", version = "v1")]
+pub struct ControllerArgs {
+    pub base_path: String,
+    pub version: Option<String>,
+}
+
+impl Parse for ControllerArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let base_path = input.parse::<LitStr>()?.value();
+        let mut version = None;
+
+        if input.parse::<Token![,]>().is_ok() && input.peek(Ident) {
+            let ident = input.parse::<Ident>()?;
+
+            if ident == "version" {
+                input.parse::<Token![=]>()?;
+                let ver = input.parse::<LitStr>()?;
+                let ver_str = ver.value();
+
+                if !VERSION_REGEX.is_match(&ver_str) {
+                    return Err(syn::Error::new(
+                        ver.span(),
+                        "Invalid version format",
+                    ));
+                }
+
+                version = Some(ver_str);
+            }
+        }
+
+        Ok(ControllerArgs { base_path, version })
+    }
+}

--- a/sword-macros/src/controller/parsing/fields.rs
+++ b/sword-macros/src/controller/parsing/fields.rs
@@ -1,0 +1,17 @@
+use syn::{Ident, ItemStruct, Type};
+
+pub fn collect_controller_fields(item: &ItemStruct) -> Vec<(Ident, Type)> {
+    match &item.fields {
+        syn::Fields::Named(named_fields) => named_fields
+            .named
+            .iter()
+            .filter_map(|field| {
+                field
+                    .ident
+                    .as_ref()
+                    .map(|ident| (ident.clone(), field.ty.clone()))
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}

--- a/sword-macros/src/controller/parsing/mod.rs
+++ b/sword-macros/src/controller/parsing/mod.rs
@@ -1,8 +1,16 @@
+mod attributes;
+mod fields;
+
 use proc_macro::TokenStream;
 use proc_macro_error::emit_error;
-use syn::{Ident, ItemStruct, LitStr, Type};
+use syn::{Ident, ItemStruct, Type};
 
-use crate::middleware::parse::MiddlewareArgs;
+use crate::{
+    controller::parsing::{
+        attributes::ControllerArgs, fields::collect_controller_fields,
+    },
+    middleware::parse::MiddlewareArgs,
+};
 
 pub struct ControllerInput {
     pub struct_name: Ident,
@@ -16,7 +24,7 @@ pub fn parse_controller_input(
     item: TokenStream,
 ) -> Result<ControllerInput, syn::Error> {
     let input = syn::parse::<ItemStruct>(item)?;
-    let args = syn::parse::<LitStr>(attr)?;
+    let args = syn::parse::<ControllerArgs>(attr)?;
 
     let mut middlewares = vec![];
     let fields = collect_controller_fields(&input);
@@ -30,26 +38,29 @@ pub fn parse_controller_input(
         }
     }
 
+    if args.base_path.is_empty() {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "Base path cannot be empty. Use \"/\" for root path",
+        ));
+    }
+
+    if !args.base_path.starts_with('/') {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "Controller base path must start with '/'",
+        ));
+    }
+
+    let base_path = match args.version {
+        Some(ver) => format!("/{}/{}", ver, args.base_path.trim_start_matches('/')),
+        None => args.base_path,
+    };
+
     Ok(ControllerInput {
-        base_path: args.value(),
+        base_path,
         struct_name: input.ident,
         fields,
         middlewares,
     })
-}
-
-pub fn collect_controller_fields(item: &ItemStruct) -> Vec<(Ident, Type)> {
-    match &item.fields {
-        syn::Fields::Named(named_fields) => named_fields
-            .named
-            .iter()
-            .filter_map(|field| {
-                field
-                    .ident
-                    .as_ref()
-                    .map(|ident| (ident.clone(), field.ty.clone()))
-            })
-            .collect(),
-        _ => Vec::new(),
-    }
 }

--- a/sword-tests/src/application/versioning.rs
+++ b/sword-tests/src/application/versioning.rs
@@ -1,0 +1,420 @@
+use axum_test::TestServer;
+use serde_json::{Value, json};
+use sword::prelude::*;
+
+fn test_server() -> TestServer {
+    let app = Application::builder()
+        .with_controller::<V1UsersController>()
+        .with_controller::<V2UsersController>()
+        .with_controller::<V1ProductsController>()
+        .with_controller::<V2ProductsController>()
+        .build();
+
+    TestServer::new(app.router()).unwrap()
+}
+
+// ================== V1 Controllers ==================
+
+#[controller("/users", version = "v1")]
+pub struct V1UsersController {}
+
+#[routes]
+impl V1UsersController {
+    #[get("/")]
+    async fn list_users(&self) -> HttpResponse {
+        HttpResponse::Ok()
+            .data(json!({
+                "version": "v1",
+                "users": [
+                    {"id": 1, "name": "Alice"},
+                    {"id": 2, "name": "Bob"}
+                ]
+            }))
+            .message("Users retrieved (v1)")
+    }
+
+    #[get("/{id}")]
+    async fn get_user(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let id = ctx.param::<u32>("id")?;
+
+        Ok(HttpResponse::Ok()
+            .data(json!({
+                "version": "v1",
+                "user": {
+                    "id": id,
+                    "name": "Alice"
+                }
+            }))
+            .message("User retrieved (v1)"))
+    }
+
+    #[post("/")]
+    async fn create_user(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let body = ctx.body::<Value>()?;
+
+        Ok(HttpResponse::Created()
+            .data(json!({
+                "version": "v1",
+                "user": body
+            }))
+            .message("User created (v1)"))
+    }
+}
+
+#[controller("/products", version = "v1")]
+pub struct V1ProductsController {}
+
+#[routes]
+impl V1ProductsController {
+    #[get("/")]
+    async fn list_products(&self) -> HttpResponse {
+        HttpResponse::Ok()
+            .data(json!({
+                "version": "v1",
+                "products": [
+                    {"id": 1, "name": "Laptop", "price": 999.99},
+                    {"id": 2, "name": "Mouse", "price": 29.99}
+                ]
+            }))
+            .message("Products retrieved (v1)")
+    }
+
+    #[get("/{id}")]
+    async fn get_product(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let id = ctx.param::<u32>("id")?;
+
+        Ok(HttpResponse::Ok()
+            .data(json!({
+                "version": "v1",
+                "product": {
+                    "id": id,
+                    "name": "Laptop",
+                    "price": 999.99
+                }
+            }))
+            .message("Product retrieved (v1)"))
+    }
+}
+
+// ================== V2 Controllers ==================
+
+#[controller("/users", version = "v2")]
+pub struct V2UsersController {}
+
+#[routes]
+impl V2UsersController {
+    #[get("/")]
+    async fn list_users(&self) -> HttpResponse {
+        HttpResponse::Ok()
+            .data(json!({
+                "version": "v2",
+                "users": [
+                    {"id": 1, "name": "Alice", "email": "alice@example.com", "active": true},
+                    {"id": 2, "name": "Bob", "email": "bob@example.com", "active": true}
+                ],
+                "meta": {
+                    "total": 2,
+                    "page": 1
+                }
+            }))
+            .message("Users retrieved (v2)")
+    }
+
+    #[get("/{id}")]
+    async fn get_user(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let id = ctx.param::<u32>("id")?;
+
+        Ok(HttpResponse::Ok()
+            .data(json!({
+                "version": "v2",
+                "user": {
+                    "id": id,
+                    "name": "Alice",
+                    "email": "alice@example.com",
+                    "active": true,
+                    "created_at": "2025-10-06T00:00:00Z"
+                }
+            }))
+            .message("User retrieved (v2)"))
+    }
+
+    #[post("/")]
+    async fn create_user(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let body = ctx.body::<Value>()?;
+
+        Ok(HttpResponse::Created()
+            .data(json!({
+                "version": "v2",
+                "user": body,
+                "meta": {
+                    "created_at": "2025-10-06T00:00:00Z"
+                }
+            }))
+            .message("User created (v2)"))
+    }
+}
+
+#[controller("/products", version = "v2")]
+pub struct V2ProductsController {}
+
+#[routes]
+impl V2ProductsController {
+    #[get("/")]
+    async fn list_products(&self) -> HttpResponse {
+        HttpResponse::Ok()
+            .data(json!({
+                "version": "v2",
+                "products": [
+                    {
+                        "id": 1,
+                        "name": "Laptop",
+                        "price": 999.99,
+                        "currency": "USD",
+                        "stock": 50,
+                        "category": "Electronics"
+                    },
+                    {
+                        "id": 2,
+                        "name": "Mouse",
+                        "price": 29.99,
+                        "currency": "USD",
+                        "stock": 200,
+                        "category": "Accessories"
+                    }
+                ],
+                "meta": {
+                    "total": 2,
+                    "page": 1
+                }
+            }))
+            .message("Products retrieved (v2)")
+    }
+
+    #[get("/{id}")]
+    async fn get_product(&self, ctx: Context) -> HttpResult<HttpResponse> {
+        let id = ctx.param::<u32>("id")?;
+
+        Ok(HttpResponse::Ok()
+            .data(json!({
+                "version": "v2",
+                "product": {
+                    "id": id,
+                    "name": "Laptop",
+                    "price": 999.99,
+                    "currency": "USD",
+                    "stock": 50,
+                    "category": "Electronics",
+                    "description": "High-performance laptop"
+                }
+            }))
+            .message("Product retrieved (v2)"))
+    }
+}
+
+// ================== Tests ==================
+
+#[tokio::test]
+async fn test_v1_users_list() {
+    let server = test_server();
+
+    let response = server.get("/v1/users").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["success"], true);
+    assert_eq!(json_value["message"], "Users retrieved (v1)");
+    assert_eq!(json_value["data"]["version"], "v1");
+    assert_eq!(json_value["data"]["users"][0]["name"], "Alice");
+    assert_eq!(json_value["data"]["users"][1]["name"], "Bob");
+}
+
+#[tokio::test]
+async fn test_v2_users_list() {
+    let server = test_server();
+
+    let response = server.get("/v2/users").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["success"], true);
+    assert_eq!(json_value["message"], "Users retrieved (v2)");
+    assert_eq!(json_value["data"]["version"], "v2");
+    assert_eq!(json_value["data"]["users"][0]["email"], "alice@example.com");
+    assert_eq!(json_value["data"]["meta"]["total"], 2);
+}
+
+#[tokio::test]
+async fn test_v1_users_get_by_id() {
+    let server = test_server();
+
+    let response = server.get("/v1/users/1").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["success"], true);
+    assert_eq!(json_value["message"], "User retrieved (v1)");
+    assert_eq!(json_value["data"]["version"], "v1");
+    assert_eq!(json_value["data"]["user"]["id"], 1);
+    assert_eq!(json_value["data"]["user"]["name"], "Alice");
+}
+
+#[tokio::test]
+async fn test_v2_users_get_by_id() {
+    let server = test_server();
+
+    let response = server.get("/v2/users/42").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["data"]["version"], "v2");
+    assert_eq!(json_value["data"]["user"]["id"], 42);
+    assert_eq!(json_value["data"]["user"]["email"], "alice@example.com");
+    assert!(json_value["data"]["user"]["created_at"].is_string());
+}
+
+#[tokio::test]
+async fn test_v1_users_create() {
+    let server = test_server();
+
+    let response = server
+        .post("/v1/users")
+        .json(&json!({
+            "name": "Charlie"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 201);
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["message"], "User created (v1)");
+    assert_eq!(json_value["data"]["version"], "v1");
+    assert_eq!(json_value["data"]["user"]["name"], "Charlie");
+}
+
+#[tokio::test]
+async fn test_v2_users_create() {
+    let server = test_server();
+
+    let response = server
+        .post("/v2/users")
+        .json(&json!({
+            "name": "Charlie",
+            "email": "charlie@example.com"
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 201);
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["message"], "User created (v2)");
+    assert_eq!(json_value["data"]["version"], "v2");
+    assert_eq!(json_value["data"]["user"]["email"], "charlie@example.com");
+    assert!(json_value["data"]["meta"]["created_at"].is_string());
+}
+
+#[tokio::test]
+async fn test_v1_products_list() {
+    let server = test_server();
+
+    let response = server.get("/v1/products").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["success"], true);
+    assert_eq!(json_value["message"], "Products retrieved (v1)");
+    assert_eq!(json_value["data"]["version"], "v1");
+    assert_eq!(json_value["data"]["products"][0]["name"], "Laptop");
+    assert_eq!(json_value["data"]["products"][0]["price"], 999.99);
+}
+
+#[tokio::test]
+async fn test_v2_products_list() {
+    let server = test_server();
+
+    let response = server.get("/v2/products").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["data"]["version"], "v2");
+    assert_eq!(json_value["data"]["products"][0]["currency"], "USD");
+    assert_eq!(json_value["data"]["products"][0]["stock"], 50);
+    assert_eq!(json_value["data"]["products"][0]["category"], "Electronics");
+}
+
+#[tokio::test]
+async fn test_v1_products_get_by_id() {
+    let server = test_server();
+
+    let response = server.get("/v1/products/1").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["success"], true);
+    assert_eq!(json_value["message"], "Product retrieved (v1)");
+    assert_eq!(json_value["data"]["version"], "v1");
+    assert_eq!(json_value["data"]["product"]["id"], 1);
+    assert_eq!(json_value["data"]["product"]["name"], "Laptop");
+    assert_eq!(json_value["data"]["product"]["price"], 999.99);
+}
+
+#[tokio::test]
+async fn test_v2_products_get_by_id() {
+    let server = test_server();
+
+    let response = server.get("/v2/products/5").await;
+
+    response.assert_status_ok();
+
+    let json_value = response.json::<Value>();
+    assert_eq!(json_value["data"]["version"], "v2");
+    assert_eq!(json_value["data"]["product"]["id"], 5);
+    assert_eq!(json_value["data"]["product"]["currency"], "USD");
+    assert_eq!(
+        json_value["data"]["product"]["description"],
+        "High-performance laptop"
+    );
+}
+
+#[tokio::test]
+async fn test_different_versions_isolated() {
+    let server = test_server();
+
+    let v1_response = server.get("/v1/users").await;
+    let v2_response = server.get("/v2/users").await;
+
+    let v1_json = v1_response.json::<Value>();
+    let v2_json = v2_response.json::<Value>();
+
+    assert!(v1_json["data"]["users"][0]["email"].is_null());
+    assert!(v1_json["data"]["meta"].is_null());
+
+    assert_eq!(v2_json["data"]["users"][0]["email"], "alice@example.com");
+    assert_eq!(v2_json["data"]["meta"]["total"], 2);
+}
+
+#[tokio::test]
+async fn test_versioned_routes_path_isolation() {
+    let server = test_server();
+
+    let v1_users = server.get("/v1/users/123").await;
+    let v2_users = server.get("/v2/users/123").await;
+    let v1_products = server.get("/v1/products/456").await;
+    let v2_products = server.get("/v2/products/456").await;
+
+    v1_users.assert_status_ok();
+    v2_users.assert_status_ok();
+    v1_products.assert_status_ok();
+    v2_products.assert_status_ok();
+
+    assert_eq!(v1_users.json::<Value>()["data"]["version"], "v1");
+    assert_eq!(v2_users.json::<Value>()["data"]["version"], "v2");
+    assert_eq!(v1_products.json::<Value>()["data"]["version"], "v1");
+    assert_eq!(v2_products.json::<Value>()["data"]["version"], "v2");
+}

--- a/sword-tests/src/lib.rs
+++ b/sword-tests/src/lib.rs
@@ -18,6 +18,7 @@ mod application {
     mod config;
     mod di;
     mod state;
+    mod versioning;
 }
 
 #[cfg(test)]

--- a/sword-tests/src/middlewares/handler_level.rs
+++ b/sword-tests/src/middlewares/handler_level.rs
@@ -4,7 +4,6 @@ use sword::prelude::*;
 use sword::web::HttpResult;
 use tower_http::cors::CorsLayer;
 
-// Enums para testing
 #[derive(Debug, Clone)]
 pub enum LogLevel {
     Debug,
@@ -36,9 +35,9 @@ impl MiddlewareWithConfig<(&str, &str)> for FileValidationMiddleware {
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Validating file with config: {:?}", config);
         ctx.extensions
             .insert((config.0.to_string(), config.1.to_string()));
+
         next!(ctx, next)
     }
 }
@@ -75,19 +74,15 @@ impl MiddlewareWithConfig<Vec<&str>> for RoleMiddleware {
         mut ctx: Context,
         nxt: Next,
     ) -> MiddlewareResult {
-        dbg!(&roles);
         let roles_owned: Vec<String> = roles.iter().map(|s| s.to_string()).collect();
         ctx.extensions.insert(roles_owned);
+
         next!(ctx, nxt)
     }
 }
 
-// ================================
-// MIDDLEWARES PARA TESTING DE DIFERENTES TIPOS DE CONFIG
-// ================================
-
-// Middleware para probar tuplas
 struct TupleConfigMiddleware;
+
 impl MiddlewareWithConfig<(&str, &str)> for TupleConfigMiddleware {
     async fn handle(
         config: (&str, &str),
@@ -101,77 +96,74 @@ impl MiddlewareWithConfig<(&str, &str)> for TupleConfigMiddleware {
     }
 }
 
-// Middleware para probar arrays
 struct ArrayConfigMiddleware;
+
 impl MiddlewareWithConfig<[i32; 3]> for ArrayConfigMiddleware {
     async fn handle(
         config: [i32; 3],
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Array config: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar strings
 struct StringConfigMiddleware;
+
 impl MiddlewareWithConfig<String> for StringConfigMiddleware {
     async fn handle(
         config: String,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("String config: {}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar &str
 struct StrConfigMiddleware;
+
 impl MiddlewareWithConfig<&'static str> for StrConfigMiddleware {
     async fn handle(
         config: &'static str,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Str config: {}", config);
         ctx.extensions.insert(config.to_string());
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar números
 struct NumberConfigMiddleware;
 impl MiddlewareWithConfig<i32> for NumberConfigMiddleware {
     async fn handle(config: i32, mut ctx: Context, next: Next) -> MiddlewareResult {
-        println!("Number config: {}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar booleans
 struct BoolConfigMiddleware;
 impl MiddlewareWithConfig<bool> for BoolConfigMiddleware {
     async fn handle(config: bool, mut ctx: Context, next: Next) -> MiddlewareResult {
-        println!("Bool config: {}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar estructuras complejas
 struct ComplexConfigMiddleware;
+
 impl MiddlewareWithConfig<(Vec<&str>, i32, bool)> for ComplexConfigMiddleware {
     async fn handle(
         config: (Vec<&str>, i32, bool),
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Complex config: {:?}", config);
         let owned_config = (
             config
                 .0
@@ -181,12 +173,13 @@ impl MiddlewareWithConfig<(Vec<&str>, i32, bool)> for ComplexConfigMiddleware {
             config.1,
             config.2,
         );
+
         ctx.extensions.insert(owned_config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar closures/function calls
 struct FunctionConfigMiddleware;
 impl MiddlewareWithConfig<Vec<String>> for FunctionConfigMiddleware {
     async fn handle(
@@ -194,105 +187,108 @@ impl MiddlewareWithConfig<Vec<String>> for FunctionConfigMiddleware {
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Function result config: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Helper function para test
 fn create_test_vector() -> Vec<String> {
     vec!["test1".to_string(), "test2".to_string()]
 }
 
-// Middleware para probar expresiones matemáticas
 struct MathConfigMiddleware;
+
 impl MiddlewareWithConfig<i32> for MathConfigMiddleware {
     async fn handle(config: i32, mut ctx: Context, next: Next) -> MiddlewareResult {
-        println!("Math result: {}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
-// Middleware para probar referencias y constantes
 struct ConstConfigMiddleware;
+
 impl MiddlewareWithConfig<&'static str> for ConstConfigMiddleware {
     async fn handle(
         config: &'static str,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Const config: {}", config);
         ctx.extensions.insert(config.to_string());
+
         next!(ctx, next)
     }
 }
 
 const TEST_CONST: &str = "const_value";
 
-// Middlewares para enum variants
 struct LogMiddleware;
+
 impl MiddlewareWithConfig<LogLevel> for LogMiddleware {
     async fn handle(
         config: LogLevel,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Log level: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
 struct DatabaseMiddleware;
+
 impl MiddlewareWithConfig<DatabaseConfig> for DatabaseMiddleware {
     async fn handle(
         config: DatabaseConfig,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Database config: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
 struct AuthMiddleware;
+
 impl MiddlewareWithConfig<AuthMethod> for AuthMiddleware {
     async fn handle(
         config: AuthMethod,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Auth method: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
 struct EnumOptionMiddleware;
+
 impl MiddlewareWithConfig<Option<LogLevel>> for EnumOptionMiddleware {
     async fn handle(
         config: Option<LogLevel>,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Optional log level: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
 
 struct EnumVecMiddleware;
+
 impl MiddlewareWithConfig<Vec<LogLevel>> for EnumVecMiddleware {
     async fn handle(
         config: Vec<LogLevel>,
         mut ctx: Context,
         next: Next,
     ) -> MiddlewareResult {
-        println!("Log levels: {:?}", config);
         ctx.extensions.insert(config);
+
         next!(ctx, next)
     }
 }
@@ -368,10 +364,6 @@ impl TestController {
             .message("Test with tower middleware")
             .data(json!({"middleware": "cors"}))
     }
-
-    // ================================
-    // HANDLERS PARA TESTING DE DIFERENTES TIPOS DE CONFIG
-    // ================================
 
     #[get("/tuple-config-test")]
     #[middleware(TupleConfigMiddleware, config = ("jpg", "png"))]
@@ -524,7 +516,6 @@ impl TestController {
             }))
     }
 
-    // Casos extremos adicionales
     #[get("/math-config-test")]
     #[middleware(MathConfigMiddleware, config = 2 + 3 * 4 - 1)]
     async fn math_config_test(&self, ctx: Context) -> HttpResponse {
@@ -812,10 +803,6 @@ async fn tower_middleware_test() {
     assert_eq!(data["middleware"], "cors");
 }
 
-// ================================
-// TESTS PARA DIFERENTES TIPOS DE CONFIG
-// ================================
-
 #[tokio::test]
 async fn tuple_config_middleware_test() {
     let app = Application::builder()
@@ -966,7 +953,6 @@ async fn nested_config_middleware_test() {
     assert_eq!(json.data.unwrap()["config_type"], "nested");
 }
 
-// Tests para casos extremos
 #[tokio::test]
 async fn math_config_middleware_test() {
     let app = Application::builder()
@@ -1022,10 +1008,6 @@ async fn closure_config_middleware_test() {
     let json = response.json::<ResponseBody>();
     assert_eq!(json.data.unwrap()["config_type"], "closure");
 }
-
-// ================================
-// TESTS PARA ENUM VARIANTS
-// ================================
 
 #[tokio::test]
 async fn enum_simple_test() {


### PR DESCRIPTION
Now it's possible use api versioning syntax

```rust
#[controller("/", version = "v1")]
struct AppController {}

#[routes]
impl AppController {
    #[get("/")]
    async fn get_data(&self) -> HttpResponse {
        let data = vec![
            "This is a basic web server",
            "It serves static data",
            "You can extend it with more routes",
        ];

        HttpResponse::Ok().data(data)
    }
}
```